### PR TITLE
Verify options is a hash before pulling out confirm

### DIFF
--- a/lib/sweet-alert2-rails/view_helpers.rb
+++ b/lib/sweet-alert2-rails/view_helpers.rb
@@ -33,7 +33,7 @@ module SweetAlert2Rails
     protected
 
     def options_has_confirm?(options)
-      options[:data] && options[:data][:confirm]
+      options.is_a?(Hash) && options[:data] && options[:data][:confirm]
     end
   end
 end


### PR DESCRIPTION
In places were I had `f.button :submit` in Rails 5, I was getting this exception:

```
no implicit conversion of Symbol into Integer
```

This is because `options` for `f.button` was set as `:submit` rather than a Hash.